### PR TITLE
fix for husky-precommit warning

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact = true
+scripts-prepend-node-path=true


### PR DESCRIPTION
Before this change, upon commit, husky would emit the following warning:
```shell
git commit -m 'random commit'

husky > pre-commit (node v12.18.2)
npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1593727944619-0.14911884548431797/node but npm is using /usr/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
```
After this change the warning is resolved.  See https://stackoverflow.com/a/51295237/7262049 for details.