### PR TITLE
refactor: ♻️ fixes initiate typo in tests

### DIFF
--- a/internals/startingTemplate/src/locales/__tests__/i18n.test.ts
+++ b/internals/startingTemplate/src/locales/__tests__/i18n.test.ts
@@ -1,7 +1,7 @@
 import { i18n } from '../i18n';
 
 describe('i18n', () => {
-  it('should initate i18n', async () => {
+  it('should initiate i18n', async () => {
     const t = await i18n;
     expect(t).toBeDefined();
   });

--- a/src/locales/__tests__/i18n.test.ts
+++ b/src/locales/__tests__/i18n.test.ts
@@ -1,12 +1,12 @@
 import { i18n, translations } from '../i18n';
 
 describe('i18n', () => {
-  it('should initate i18n', async () => {
+  it('should initiate i18n', async () => {
     const t = await i18n;
     expect(t).toBeDefined();
   });
 
-  it('should initate i18n with translations', async () => {
+  it('should initiate i18n with translations', async () => {
     const t = await i18n;
     expect(t(translations.feedbackFeature.description).length).toBeGreaterThan(
       0,


### PR DESCRIPTION
Fixes a typo in a couple of tests. `initate` => `initiate`.