### PR TITLE
chore: 🔧 added component folder selection to generators

### DIFF
--- a/internals/generators/component/index.ts
+++ b/internals/generators/component/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { Actions, PlopGeneratorConfig } from 'node-plop';
+import path from 'path';
 
 import { componentExists, listComponentsDirectories } from '../utils';
 
@@ -73,7 +74,11 @@ export const componentGenerator: PlopGeneratorConfig = {
     },
   ],
   actions: (data: { [P in ComponentProptNames]: string }) => {
-    const componentPath = `${data.componentPath}/{{properCase ${ComponentProptNames.ComponentName}}}`;
+    const componentPath = `${path.join(
+      __dirname,
+      '../../../',
+      data.componentPath,
+    )}/{{properCase ${ComponentProptNames.ComponentName}}}`;
 
     const actions: Actions = [
       {

--- a/internals/generators/component/index.ts
+++ b/internals/generators/component/index.ts
@@ -3,19 +3,18 @@
  */
 
 import { Actions, PlopGeneratorConfig } from 'node-plop';
-import path from 'path';
 
-import { componentExists } from '../utils';
+import { componentExists, listComponentsDirectories } from '../utils';
 
 export enum ComponentProptNames {
   'ComponentName' = 'ComponentName',
+  'componentPath' = 'componentPath',
   'wantMemo' = 'wantMemo',
   'wantStyledComponents' = 'wantStyledComponents',
   'wantTranslations' = 'wantTranslations',
   'wantLoadable' = 'wantLoadable',
   'wantTests' = 'wantTests',
 }
-const componentsPath = path.join(__dirname, '../../../src/app/components');
 
 export const componentGenerator: PlopGeneratorConfig = {
   description: 'Add an unconnected component',
@@ -34,6 +33,12 @@ export const componentGenerator: PlopGeneratorConfig = {
 
         return 'The name is required';
       },
+    },
+    {
+      type: 'list',
+      name: ComponentProptNames.componentPath,
+      message: 'Where should it be created ?',
+      choices: listComponentsDirectories(),
     },
     {
       type: 'confirm',
@@ -68,7 +73,7 @@ export const componentGenerator: PlopGeneratorConfig = {
     },
   ],
   actions: (data: { [P in ComponentProptNames]: string }) => {
-    const componentPath = `${componentsPath}/{{properCase ${ComponentProptNames.ComponentName}}}`;
+    const componentPath = `${data.componentPath}/{{properCase ${ComponentProptNames.ComponentName}}}`;
 
     const actions: Actions = [
       {
@@ -108,7 +113,7 @@ export const componentGenerator: PlopGeneratorConfig = {
 
     actions.push({
       type: 'prettify',
-      data: { path: `${componentsPath}/${data.ComponentName}/**` },
+      data: { path: `${data.componentPath}/${data.ComponentName}/**` },
     });
 
     return actions;

--- a/internals/generators/utils/index.ts
+++ b/internals/generators/utils/index.ts
@@ -20,3 +20,22 @@ export function containerExists(container: string) {
   );
   return containers.indexOf(container) >= 0;
 }
+
+function walkDir(directory: string) {
+  let dirList: string[] = [];
+
+  const files = fs.readdirSync(directory);
+  for (const file of files) {
+    const p = path.join(directory, file);
+    if (fs.statSync(p).isDirectory()) {
+      dirList.push(p);
+      dirList = [...dirList, ...walkDir(p)];
+    }
+  }
+  return dirList;
+}
+
+export function listComponentsDirectories() {
+  const sourceDir = 'src/';
+  return walkDir(sourceDir).filter(dirPath => dirPath.match(/components$/));
+}

--- a/internals/generators/utils/index.ts
+++ b/internals/generators/utils/index.ts
@@ -36,6 +36,7 @@ function walkDir(directory: string) {
 }
 
 export function listComponentsDirectories() {
+  // Not using path.join(__dirname,) as it give really long name when listed
   const sourceDir = 'src/';
   return walkDir(sourceDir).filter(dirPath => dirPath.match(/components$/));
 }

--- a/internals/testing/test-generators.ts
+++ b/internals/testing/test-generators.ts
@@ -120,6 +120,7 @@ async function generateComponent() {
     const p = componentGen
       .runActions<ComponentProptNames>({
         ComponentName: name,
+        componentPath: 'src/app/components',
         wantMemo: values[0],
         wantStyledComponents: values[1],
         wantLoadable: values[2],


### PR DESCRIPTION
This MR add folder selection for the component generator so we can create components also in `containers/components` folders
![plopgen](https://user-images.githubusercontent.com/23508913/95633307-b0eb3780-0a87-11eb-966a-45d909f8bd30.gif)
