### PR TITLE
feat: ✨ fix i18n test

### DIFF
--- a/internals/generators/component/index.test.tsx.hbs
+++ b/internals/generators/component/index.test.tsx.hbs
@@ -3,6 +3,19 @@ import { render } from '@testing-library/react';
 
 import { {{ properCase ComponentName }} } from '..';
 
+{{#if wantTranslations}}
+jest.mock('react-i18next', () => ({
+  useTranslation: () => {
+    return {
+      t: str => str,
+      i18n: {
+        changeLanguage: () => new Promise(() => {}),
+      },
+    };
+  },
+}));
+{{/if}}
+
 describe('<{{ properCase ComponentName }}  />', () => {
   it('should match snapshot', () => {
     const loadingIndicator = render(<{{ properCase ComponentName }} />);


### PR DESCRIPTION
if the component uses i18n, then an error occurs during testing:
console.warn
    react-i18next:: You will need to pass in an i18next instance by using initReactI18next

```
      11 | export function Test(props: Props) {
    > 12 |   const { t } = useTranslation();
         |                 ^
      13 |   return <Div>{t('translations.someThing')}</Div>;
      14 | }
```
 


in the documentation i18n this is solved by mock (https://react.i18next.com/misc/testing).


```
jest.mock('react-i18next', () => ({
  useTranslation: () => {
    return {
      t: (str) => str,
      i18n: {
        changeLanguage: () => new Promise(() => {}),
      },
    };
  },
}));
```