### PR TITLE
chore: 🔧 bumped node version to 14 LTS

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/fermium

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "engines": {
     "yarn": ">=1.22.10",
-    "node": ">=14.0.0"
+    "node": ">=14.15.0"
   },
   "bugs": {
     "url": "https://github.com/react-boilerplate/react-boilerplate-cra-template/issues"

--- a/template.json
+++ b/template.json
@@ -2,7 +2,7 @@
   "package": {
     "engines": {
       "yarn": ">=1.22.10",
-      "node": ">=14.0.0"
+      "node": ">=14.15.0"
     },
     "scripts": {
       "test:generators": "ts-node --project=./internals/ts-node.tsconfig.json ./internals/testing/generators/test-generators.ts",


### PR DESCRIPTION
Change node version to Active LTS for nvm (lts/fermium) and package(v14.15.0 or greater). https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md

- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [x] Double-check your branch is based on `dev` and targets `dev`
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues
