### PR TITLE
chore: 🔧 add support of scoped package name

### DIFF
--- a/internals/scripts/create-npm-package.ts
+++ b/internals/scripts/create-npm-package.ts
@@ -5,9 +5,7 @@ import {
 } from './create-template-folder';
 import { shellEnableAbortOnFail, shellDisableAbortOnFail } from './utils';
 
-const packageName = require('../../package.json').name;
-const packageVersion = require('../../package.json').version;
-const packageFolder = `.${packageName}`;
+const packageFolder = '.cra-template-rb';
 interface Options {}
 
 export function createNpmPackage(opts: Options = {}) {
@@ -17,9 +15,13 @@ export function createNpmPackage(opts: Options = {}) {
 
   crateTemplateFolder(opts);
 
-  shell.exec(`npm pack`, { silent: true });
+  // Create a tarball archive and get filename of generated archive from stdout
+  const archiveFilename = shell
+    .exec(`npm pack`, { silent: true })
+    .stdout.trim();
+
   shell.exec(
-    `tar -xvf ${packageName}-${packageVersion}.tgz && mv package ${packageFolder} && rm ${packageName}-${packageVersion}.tgz`,
+    `tar -xvf ${archiveFilename} && mv package ${packageFolder} && rm ${archiveFilename}`,
     { silent: true },
   );
 


### PR DESCRIPTION
Сhanges simplify the code and add support for scope in the package name (e.g.
@react-boilerplate/cra-template-rb)

I added a comment and replaced the non-obvious regex. This changes will add the ability to rename the package to scoped package in the fork and publish user's templates based on react-boilerplate-cra-template.

- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [x] Double-check your branch is based on `dev` and targets `dev`
- [ ] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues
