### PR TITLE
chore(deps): update web-vitals v2.1.2 to v2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "redux-saga": "1.1.3",
     "sanitize.css": "13.0.0",
     "styled-components": "5.3.3",
-    "web-vitals": "2.1.2"
+    "web-vitals": "2.1.4"
   },
   "devDependencies": {
     "@commitlint/cli": "13.1.0",

--- a/template.json
+++ b/template.json
@@ -55,7 +55,7 @@
       "redux-saga": "1.1.3",
       "sanitize.css": "13.0.0",
       "styled-components": "5.3.3",
-      "web-vitals": "2.1.2",
+      "web-vitals": "2.1.4",
 
       "@testing-library/jest-dom": "5.16.1",
       "@testing-library/react": "12.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12370,10 +12370,10 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-vitals@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.2.tgz#3a6c8faebf9097a6ccd17f5f45c9485d8d62dab1"
-  integrity sha512-nZnEH8dj+vJFqCRYdvYv0a59iLXsb8jJkt+xvXfwgnkyPdsSLtKNlYmtTDiHmTNGXeSXtpjTTUcNvFtrAk6VMQ==
+web-vitals@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.4.tgz#76563175a475a5e835264d373704f9dde718290c"
+  integrity sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## updating the web-vitals package

 I've updated the [web-vitals](https://github.com/stylelint/stylelint) package from v2.1.2 to v2.1.4. This is a really small change. See the [web-vitals changelog](https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md).

This dependency bump has been thoroughly tested despite being obviously safe.