### PR TITLE
chore(deps): update fontfaceobserver v2.1.0 to v2.3.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "1.7.1",
-    "fontfaceobserver": "2.1.0",
+    "fontfaceobserver": "2.3.0",
     "i18next": "21.6.6",
     "i18next-browser-languagedetector": "6.1.2",
     "react": "18.1.0",

--- a/template.json
+++ b/template.json
@@ -40,7 +40,7 @@
     },
     "dependencies": {
       "@reduxjs/toolkit": "1.7.1",
-      "fontfaceobserver": "2.1.0",
+      "fontfaceobserver": "2.3.0",
       "i18next": "21.6.6",
       "i18next-browser-languagedetector": "6.1.2",
       "react": "18.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5762,10 +5762,10 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
-fontfaceobserver@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz#e2705d293e2c585a6531c2a722905657317a2991"
-  integrity sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng==
+fontfaceobserver@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz#5fb392116e75d5024b7ec8e4f2ce92106d1488c8"
+  integrity sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## updating the fontfaceobserver package

I've updated the [fontfaceobserver](https://github.com/bramstein/fontfaceobserver) package from v2.1.0 to v2.3.0. This version does not bring noticeable changes. To see what's new, take a look at the [fontfaceobserver commit history](https://github.com/bramstein/fontfaceobserver/commits/master).


This dependency bump has been thoroughly tested despite being obviously safe.